### PR TITLE
Add all 148 CSS Level 4 named colors as palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Features true-color gradient trails, film-authentic katakana characters, gold hi
 - **Film-authentic characters**: Half-width katakana mixed with digits and symbols
 - **Gold highlights**: Occasional gold characters like in the original Matrix films
 - **Character mutation**: Characters flicker and change over time
-- **Multiple color palettes**: Classic green, gold, cyan, red, monochrome, purple
+- **150+ color palettes**: 9 hand-tuned featured palettes + all 148 CSS Level 4 named colors
 - **Multiple character sets**: Matrix, ASCII, binary, digits, katakana, latin
 - **Configurable**: Speed, density, FPS, palette, and charset via CLI flags
 - **Interactive controls**: Adjust speed, density, and effects in real-time with keyboard
@@ -64,14 +64,25 @@ Press `q`, `Esc`, or `Ctrl+C` to quit. Press `?` while running to show the keybi
 
 ### Color Palettes
 
+#### Featured (hand-tuned)
+
 | Name | Description |
 |---|---|
 | `classic` | Green phosphor (the Matrix default) |
 | `gold` | Warm amber/gold CRT feel |
 | `cyan` | Cold ice-blue digital |
 | `red` | Crimson danger/alert |
-| `monochrome` | White/grey on black |
+| `silver` | White/grey on black |
 | `purple` | Violet synthwave |
+| `fire` | Red/orange/yellow heat gradient |
+| `ocean` | Deep blue/teal aquatic |
+| `synthwave` | Pink/purple/cyan retro neon |
+
+#### CSS Named Colors
+
+All 148 CSS Level 4 named colors are also available as palettes. Gradients are auto-generated from the base color using HSL math. Examples: `coral`, `tomato`, `dodgerblue`, `hotpink`, `indigo`, `springgreen`, `crimson`, `orchid`.
+
+Use `--list-colors` to see the full list. Aliases: `monochrome` -> `silver`.
 
 ### Character Sets
 
@@ -101,6 +112,16 @@ digital_rain --color gold --speed 0.5 --density 2.0
 
 # Purple synthwave at 60fps
 digital_rain --color purple --fps 60
+
+# CSS named colors work directly
+digital_rain --color coral
+digital_rain --color dodgerblue --speed 1.5
+digital_rain --color hotpink --charset binary
+
+# Multi-hue featured palettes
+digital_rain --color fire
+digital_rain --color ocean --density 2.0
+digital_rain --color synthwave --fps 60
 
 # Fully randomized effect and parameters
 digital_rain --random
@@ -138,6 +159,14 @@ Speed and density are clamped to the range 0.1x - 10.0x. Status messages appear 
 
 ## Version History
 
+### v0.4.0 - CSS Color Palettes
+- All 148 CSS Level 4 named colors available as palettes (e.g. `--color coral`)
+- Auto-generated gradients from base color via HSL math
+- 3 new hand-tuned multi-hue palettes: fire, ocean, synthwave
+- Renamed "monochrome" to "silver" (CSS standard); monochrome kept as alias
+- Grouped `--list-colors` output: featured palettes + CSS colors in columns
+- Total palette count: 150+
+
 ### v0.3.1 - Auto-Cycle Timer
 - `--timer <seconds>` flag to auto-randomize effect at a configurable interval
 - `t` key to toggle auto-cycle on/off at runtime
@@ -156,7 +185,7 @@ Speed and density are clamped to the range 0.1x - 10.0x. Status messages appear 
 
 ### v0.2.0 - CLI & Configuration
 - clap-based CLI argument parsing
-- 6 color palettes: classic, gold, cyan, red, monochrome, purple
+- 6 color palettes: classic, gold, cyan, red, silver (was monochrome), purple
 - 6 character sets: matrix, ascii, binary, digits, katakana, latin
 - Configurable speed, density, and FPS
 - Effect registry with `--list-effects`, `--list-colors`, `--list-charsets`

--- a/USAGE.txt
+++ b/USAGE.txt
@@ -102,12 +102,23 @@ EFFECTS
        ocean.
 
 COLOR PALETTES
+   Featured (hand-tuned):
        classic      Green phosphor (the Matrix default)
        gold         Warm amber/gold CRT feel
        cyan         Cold ice-blue digital
        red          Crimson danger/alert
-       monochrome   White/grey on black
+       silver       White/grey on black
        purple       Violet synthwave
+       fire         Red/orange/yellow heat gradient
+       ocean        Deep blue/teal aquatic
+       synthwave    Pink/purple/cyan retro neon
+
+   CSS named colors:
+       All 148 CSS Level 4 named colors are available (e.g. coral, tomato,
+       dodgerblue, hotpink, indigo, springgreen). Gradients are auto-generated
+       from the base color. Use --list-colors to see the full list.
+
+       Aliases: monochrome -> silver
 
 CHARACTER SETS
        matrix       Half-width katakana + digits + symbols (film-authentic)
@@ -132,6 +143,12 @@ EXAMPLES
 
        Purple synthwave at 60fps:
               digital_rain --color purple --fps 60
+
+       CSS named color (auto-generated gradient):
+              digital_rain --color coral
+
+       Fire palette, heavy density:
+              digital_rain --color fire --density 2.0
 
        Forward gradient (bright tail at top):
               digital_rain --forward

--- a/src/color/css_colors.rs
+++ b/src/color/css_colors.rs
@@ -1,0 +1,968 @@
+//! All 148 CSS Level 4 named colors.
+//!
+//! Provides a lookup table for CSS color names to RGB values,
+//! used by the auto-generated palette system.
+
+/// A CSS named color with its RGB components.
+pub struct CssColor {
+    pub name: &'static str,
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+/// All 148 CSS Level 4 named colors, sorted alphabetically.
+pub const CSS_COLORS: &[CssColor] = &[
+    CssColor {
+        name: "aliceblue",
+        r: 240,
+        g: 248,
+        b: 255,
+    },
+    CssColor {
+        name: "antiquewhite",
+        r: 250,
+        g: 235,
+        b: 215,
+    },
+    CssColor {
+        name: "aqua",
+        r: 0,
+        g: 255,
+        b: 255,
+    },
+    CssColor {
+        name: "aquamarine",
+        r: 127,
+        g: 255,
+        b: 212,
+    },
+    CssColor {
+        name: "azure",
+        r: 240,
+        g: 255,
+        b: 255,
+    },
+    CssColor {
+        name: "beige",
+        r: 245,
+        g: 245,
+        b: 220,
+    },
+    CssColor {
+        name: "bisque",
+        r: 255,
+        g: 228,
+        b: 196,
+    },
+    CssColor {
+        name: "black",
+        r: 0,
+        g: 0,
+        b: 0,
+    },
+    CssColor {
+        name: "blanchedalmond",
+        r: 255,
+        g: 235,
+        b: 205,
+    },
+    CssColor {
+        name: "blue",
+        r: 0,
+        g: 0,
+        b: 255,
+    },
+    CssColor {
+        name: "blueviolet",
+        r: 138,
+        g: 43,
+        b: 226,
+    },
+    CssColor {
+        name: "brown",
+        r: 165,
+        g: 42,
+        b: 42,
+    },
+    CssColor {
+        name: "burlywood",
+        r: 222,
+        g: 184,
+        b: 135,
+    },
+    CssColor {
+        name: "cadetblue",
+        r: 95,
+        g: 158,
+        b: 160,
+    },
+    CssColor {
+        name: "chartreuse",
+        r: 127,
+        g: 255,
+        b: 0,
+    },
+    CssColor {
+        name: "chocolate",
+        r: 210,
+        g: 105,
+        b: 30,
+    },
+    CssColor {
+        name: "coral",
+        r: 255,
+        g: 127,
+        b: 80,
+    },
+    CssColor {
+        name: "cornflowerblue",
+        r: 100,
+        g: 149,
+        b: 237,
+    },
+    CssColor {
+        name: "cornsilk",
+        r: 255,
+        g: 248,
+        b: 220,
+    },
+    CssColor {
+        name: "crimson",
+        r: 220,
+        g: 20,
+        b: 60,
+    },
+    CssColor {
+        name: "cyan",
+        r: 0,
+        g: 255,
+        b: 255,
+    },
+    CssColor {
+        name: "darkblue",
+        r: 0,
+        g: 0,
+        b: 139,
+    },
+    CssColor {
+        name: "darkcyan",
+        r: 0,
+        g: 139,
+        b: 139,
+    },
+    CssColor {
+        name: "darkgoldenrod",
+        r: 184,
+        g: 134,
+        b: 11,
+    },
+    CssColor {
+        name: "darkgray",
+        r: 169,
+        g: 169,
+        b: 169,
+    },
+    CssColor {
+        name: "darkgreen",
+        r: 0,
+        g: 100,
+        b: 0,
+    },
+    CssColor {
+        name: "darkgrey",
+        r: 169,
+        g: 169,
+        b: 169,
+    },
+    CssColor {
+        name: "darkkhaki",
+        r: 189,
+        g: 183,
+        b: 107,
+    },
+    CssColor {
+        name: "darkmagenta",
+        r: 139,
+        g: 0,
+        b: 139,
+    },
+    CssColor {
+        name: "darkolivegreen",
+        r: 85,
+        g: 107,
+        b: 47,
+    },
+    CssColor {
+        name: "darkorange",
+        r: 255,
+        g: 140,
+        b: 0,
+    },
+    CssColor {
+        name: "darkorchid",
+        r: 153,
+        g: 50,
+        b: 204,
+    },
+    CssColor {
+        name: "darkred",
+        r: 139,
+        g: 0,
+        b: 0,
+    },
+    CssColor {
+        name: "darksalmon",
+        r: 233,
+        g: 150,
+        b: 122,
+    },
+    CssColor {
+        name: "darkseagreen",
+        r: 143,
+        g: 188,
+        b: 143,
+    },
+    CssColor {
+        name: "darkslateblue",
+        r: 72,
+        g: 61,
+        b: 139,
+    },
+    CssColor {
+        name: "darkslategray",
+        r: 47,
+        g: 79,
+        b: 79,
+    },
+    CssColor {
+        name: "darkslategrey",
+        r: 47,
+        g: 79,
+        b: 79,
+    },
+    CssColor {
+        name: "darkturquoise",
+        r: 0,
+        g: 206,
+        b: 209,
+    },
+    CssColor {
+        name: "darkviolet",
+        r: 148,
+        g: 0,
+        b: 211,
+    },
+    CssColor {
+        name: "deeppink",
+        r: 255,
+        g: 20,
+        b: 147,
+    },
+    CssColor {
+        name: "deepskyblue",
+        r: 0,
+        g: 191,
+        b: 255,
+    },
+    CssColor {
+        name: "dimgray",
+        r: 105,
+        g: 105,
+        b: 105,
+    },
+    CssColor {
+        name: "dimgrey",
+        r: 105,
+        g: 105,
+        b: 105,
+    },
+    CssColor {
+        name: "dodgerblue",
+        r: 30,
+        g: 144,
+        b: 255,
+    },
+    CssColor {
+        name: "firebrick",
+        r: 178,
+        g: 34,
+        b: 34,
+    },
+    CssColor {
+        name: "floralwhite",
+        r: 255,
+        g: 250,
+        b: 240,
+    },
+    CssColor {
+        name: "forestgreen",
+        r: 34,
+        g: 139,
+        b: 34,
+    },
+    CssColor {
+        name: "fuchsia",
+        r: 255,
+        g: 0,
+        b: 255,
+    },
+    CssColor {
+        name: "gainsboro",
+        r: 220,
+        g: 220,
+        b: 220,
+    },
+    CssColor {
+        name: "ghostwhite",
+        r: 248,
+        g: 248,
+        b: 255,
+    },
+    CssColor {
+        name: "gold",
+        r: 255,
+        g: 215,
+        b: 0,
+    },
+    CssColor {
+        name: "goldenrod",
+        r: 218,
+        g: 165,
+        b: 32,
+    },
+    CssColor {
+        name: "gray",
+        r: 128,
+        g: 128,
+        b: 128,
+    },
+    CssColor {
+        name: "green",
+        r: 0,
+        g: 128,
+        b: 0,
+    },
+    CssColor {
+        name: "greenyellow",
+        r: 173,
+        g: 255,
+        b: 47,
+    },
+    CssColor {
+        name: "grey",
+        r: 128,
+        g: 128,
+        b: 128,
+    },
+    CssColor {
+        name: "honeydew",
+        r: 240,
+        g: 255,
+        b: 240,
+    },
+    CssColor {
+        name: "hotpink",
+        r: 255,
+        g: 105,
+        b: 180,
+    },
+    CssColor {
+        name: "indianred",
+        r: 205,
+        g: 92,
+        b: 92,
+    },
+    CssColor {
+        name: "indigo",
+        r: 75,
+        g: 0,
+        b: 130,
+    },
+    CssColor {
+        name: "ivory",
+        r: 255,
+        g: 255,
+        b: 240,
+    },
+    CssColor {
+        name: "khaki",
+        r: 240,
+        g: 230,
+        b: 140,
+    },
+    CssColor {
+        name: "lavender",
+        r: 230,
+        g: 230,
+        b: 250,
+    },
+    CssColor {
+        name: "lavenderblush",
+        r: 255,
+        g: 240,
+        b: 245,
+    },
+    CssColor {
+        name: "lawngreen",
+        r: 124,
+        g: 252,
+        b: 0,
+    },
+    CssColor {
+        name: "lemonchiffon",
+        r: 255,
+        g: 250,
+        b: 205,
+    },
+    CssColor {
+        name: "lightblue",
+        r: 173,
+        g: 216,
+        b: 230,
+    },
+    CssColor {
+        name: "lightcoral",
+        r: 240,
+        g: 128,
+        b: 128,
+    },
+    CssColor {
+        name: "lightcyan",
+        r: 224,
+        g: 255,
+        b: 255,
+    },
+    CssColor {
+        name: "lightgoldenrodyellow",
+        r: 250,
+        g: 250,
+        b: 210,
+    },
+    CssColor {
+        name: "lightgray",
+        r: 211,
+        g: 211,
+        b: 211,
+    },
+    CssColor {
+        name: "lightgreen",
+        r: 144,
+        g: 238,
+        b: 144,
+    },
+    CssColor {
+        name: "lightgrey",
+        r: 211,
+        g: 211,
+        b: 211,
+    },
+    CssColor {
+        name: "lightpink",
+        r: 255,
+        g: 182,
+        b: 193,
+    },
+    CssColor {
+        name: "lightsalmon",
+        r: 255,
+        g: 160,
+        b: 122,
+    },
+    CssColor {
+        name: "lightseagreen",
+        r: 32,
+        g: 178,
+        b: 170,
+    },
+    CssColor {
+        name: "lightskyblue",
+        r: 135,
+        g: 206,
+        b: 250,
+    },
+    CssColor {
+        name: "lightslategray",
+        r: 119,
+        g: 136,
+        b: 153,
+    },
+    CssColor {
+        name: "lightslategrey",
+        r: 119,
+        g: 136,
+        b: 153,
+    },
+    CssColor {
+        name: "lightsteelblue",
+        r: 176,
+        g: 196,
+        b: 222,
+    },
+    CssColor {
+        name: "lightyellow",
+        r: 255,
+        g: 255,
+        b: 224,
+    },
+    CssColor {
+        name: "lime",
+        r: 0,
+        g: 255,
+        b: 0,
+    },
+    CssColor {
+        name: "limegreen",
+        r: 50,
+        g: 205,
+        b: 50,
+    },
+    CssColor {
+        name: "linen",
+        r: 250,
+        g: 240,
+        b: 230,
+    },
+    CssColor {
+        name: "magenta",
+        r: 255,
+        g: 0,
+        b: 255,
+    },
+    CssColor {
+        name: "maroon",
+        r: 128,
+        g: 0,
+        b: 0,
+    },
+    CssColor {
+        name: "mediumaquamarine",
+        r: 102,
+        g: 205,
+        b: 170,
+    },
+    CssColor {
+        name: "mediumblue",
+        r: 0,
+        g: 0,
+        b: 205,
+    },
+    CssColor {
+        name: "mediumorchid",
+        r: 186,
+        g: 85,
+        b: 211,
+    },
+    CssColor {
+        name: "mediumpurple",
+        r: 147,
+        g: 112,
+        b: 219,
+    },
+    CssColor {
+        name: "mediumseagreen",
+        r: 60,
+        g: 179,
+        b: 113,
+    },
+    CssColor {
+        name: "mediumslateblue",
+        r: 123,
+        g: 104,
+        b: 238,
+    },
+    CssColor {
+        name: "mediumspringgreen",
+        r: 0,
+        g: 250,
+        b: 154,
+    },
+    CssColor {
+        name: "mediumturquoise",
+        r: 72,
+        g: 209,
+        b: 204,
+    },
+    CssColor {
+        name: "mediumvioletred",
+        r: 199,
+        g: 21,
+        b: 133,
+    },
+    CssColor {
+        name: "midnightblue",
+        r: 25,
+        g: 25,
+        b: 112,
+    },
+    CssColor {
+        name: "mintcream",
+        r: 245,
+        g: 255,
+        b: 250,
+    },
+    CssColor {
+        name: "mistyrose",
+        r: 255,
+        g: 228,
+        b: 225,
+    },
+    CssColor {
+        name: "moccasin",
+        r: 255,
+        g: 228,
+        b: 181,
+    },
+    CssColor {
+        name: "navajowhite",
+        r: 255,
+        g: 222,
+        b: 173,
+    },
+    CssColor {
+        name: "navy",
+        r: 0,
+        g: 0,
+        b: 128,
+    },
+    CssColor {
+        name: "oldlace",
+        r: 253,
+        g: 245,
+        b: 230,
+    },
+    CssColor {
+        name: "olive",
+        r: 128,
+        g: 128,
+        b: 0,
+    },
+    CssColor {
+        name: "olivedrab",
+        r: 107,
+        g: 142,
+        b: 35,
+    },
+    CssColor {
+        name: "orange",
+        r: 255,
+        g: 165,
+        b: 0,
+    },
+    CssColor {
+        name: "orangered",
+        r: 255,
+        g: 69,
+        b: 0,
+    },
+    CssColor {
+        name: "orchid",
+        r: 218,
+        g: 112,
+        b: 214,
+    },
+    CssColor {
+        name: "palegoldenrod",
+        r: 238,
+        g: 232,
+        b: 170,
+    },
+    CssColor {
+        name: "palegreen",
+        r: 152,
+        g: 251,
+        b: 152,
+    },
+    CssColor {
+        name: "paleturquoise",
+        r: 175,
+        g: 238,
+        b: 238,
+    },
+    CssColor {
+        name: "palevioletred",
+        r: 219,
+        g: 112,
+        b: 147,
+    },
+    CssColor {
+        name: "papayawhip",
+        r: 255,
+        g: 239,
+        b: 213,
+    },
+    CssColor {
+        name: "peachpuff",
+        r: 255,
+        g: 218,
+        b: 185,
+    },
+    CssColor {
+        name: "peru",
+        r: 205,
+        g: 133,
+        b: 63,
+    },
+    CssColor {
+        name: "pink",
+        r: 255,
+        g: 192,
+        b: 203,
+    },
+    CssColor {
+        name: "plum",
+        r: 221,
+        g: 160,
+        b: 221,
+    },
+    CssColor {
+        name: "powderblue",
+        r: 176,
+        g: 224,
+        b: 230,
+    },
+    CssColor {
+        name: "purple",
+        r: 128,
+        g: 0,
+        b: 128,
+    },
+    CssColor {
+        name: "rebeccapurple",
+        r: 102,
+        g: 51,
+        b: 153,
+    },
+    CssColor {
+        name: "red",
+        r: 255,
+        g: 0,
+        b: 0,
+    },
+    CssColor {
+        name: "rosybrown",
+        r: 188,
+        g: 143,
+        b: 143,
+    },
+    CssColor {
+        name: "royalblue",
+        r: 65,
+        g: 105,
+        b: 225,
+    },
+    CssColor {
+        name: "saddlebrown",
+        r: 139,
+        g: 69,
+        b: 19,
+    },
+    CssColor {
+        name: "salmon",
+        r: 250,
+        g: 128,
+        b: 114,
+    },
+    CssColor {
+        name: "sandybrown",
+        r: 244,
+        g: 164,
+        b: 96,
+    },
+    CssColor {
+        name: "seagreen",
+        r: 46,
+        g: 139,
+        b: 87,
+    },
+    CssColor {
+        name: "seashell",
+        r: 255,
+        g: 245,
+        b: 238,
+    },
+    CssColor {
+        name: "sienna",
+        r: 160,
+        g: 82,
+        b: 45,
+    },
+    CssColor {
+        name: "silver",
+        r: 192,
+        g: 192,
+        b: 192,
+    },
+    CssColor {
+        name: "skyblue",
+        r: 135,
+        g: 206,
+        b: 235,
+    },
+    CssColor {
+        name: "slateblue",
+        r: 106,
+        g: 90,
+        b: 205,
+    },
+    CssColor {
+        name: "slategray",
+        r: 112,
+        g: 128,
+        b: 144,
+    },
+    CssColor {
+        name: "slategrey",
+        r: 112,
+        g: 128,
+        b: 144,
+    },
+    CssColor {
+        name: "snow",
+        r: 255,
+        g: 250,
+        b: 250,
+    },
+    CssColor {
+        name: "springgreen",
+        r: 0,
+        g: 255,
+        b: 127,
+    },
+    CssColor {
+        name: "steelblue",
+        r: 70,
+        g: 130,
+        b: 180,
+    },
+    CssColor {
+        name: "tan",
+        r: 210,
+        g: 180,
+        b: 140,
+    },
+    CssColor {
+        name: "teal",
+        r: 0,
+        g: 128,
+        b: 128,
+    },
+    CssColor {
+        name: "thistle",
+        r: 216,
+        g: 191,
+        b: 216,
+    },
+    CssColor {
+        name: "tomato",
+        r: 255,
+        g: 99,
+        b: 71,
+    },
+    CssColor {
+        name: "turquoise",
+        r: 64,
+        g: 224,
+        b: 208,
+    },
+    CssColor {
+        name: "violet",
+        r: 238,
+        g: 130,
+        b: 238,
+    },
+    CssColor {
+        name: "wheat",
+        r: 245,
+        g: 222,
+        b: 179,
+    },
+    CssColor {
+        name: "white",
+        r: 255,
+        g: 255,
+        b: 255,
+    },
+    CssColor {
+        name: "whitesmoke",
+        r: 245,
+        g: 245,
+        b: 245,
+    },
+    CssColor {
+        name: "yellow",
+        r: 255,
+        g: 255,
+        b: 0,
+    },
+    CssColor {
+        name: "yellowgreen",
+        r: 154,
+        g: 205,
+        b: 50,
+    },
+];
+
+/// Look up a CSS color by name (case-insensitive).
+pub fn css_color_by_name(name: &str) -> Option<&'static CssColor> {
+    let lower = name.to_ascii_lowercase();
+    CSS_COLORS.iter().find(|c| c.name == lower)
+}
+
+/// Return the list of all CSS color names.
+pub fn css_color_names() -> Vec<&'static str> {
+    CSS_COLORS.iter().map(|c| c.name).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn css_color_count_is_148() {
+        assert_eq!(CSS_COLORS.len(), 148);
+    }
+
+    #[test]
+    fn known_color_lookups() {
+        let red = css_color_by_name("red").unwrap();
+        assert_eq!((red.r, red.g, red.b), (255, 0, 0));
+
+        let cornflower = css_color_by_name("cornflowerblue").unwrap();
+        assert_eq!((cornflower.r, cornflower.g, cornflower.b), (100, 149, 237));
+
+        let rebecca = css_color_by_name("rebeccapurple").unwrap();
+        assert_eq!((rebecca.r, rebecca.g, rebecca.b), (102, 51, 153));
+    }
+
+    #[test]
+    fn case_insensitive_lookup() {
+        assert!(css_color_by_name("Red").is_some());
+        assert!(css_color_by_name("RED").is_some());
+        assert!(css_color_by_name("CornflowerBlue").is_some());
+    }
+
+    #[test]
+    fn unknown_color_returns_none() {
+        assert!(css_color_by_name("matrixgreen").is_none());
+        assert!(css_color_by_name("notacolor").is_none());
+    }
+
+    #[test]
+    fn names_list_matches_count() {
+        assert_eq!(css_color_names().len(), 148);
+    }
+
+    #[test]
+    fn colors_are_alphabetically_sorted() {
+        let names = css_color_names();
+        for i in 1..names.len() {
+            assert!(
+                names[i - 1] <= names[i],
+                "Colors not sorted: '{}' should come before '{}'",
+                names[i - 1],
+                names[i]
+            );
+        }
+    }
+}

--- a/src/color/hsl.rs
+++ b/src/color/hsl.rs
@@ -1,0 +1,198 @@
+//! HSL (Hue, Saturation, Lightness) color conversion utilities.
+//!
+//! Used by the auto-generated palette system to derive gradient palettes
+//! from CSS named colors.
+
+/// An HSL color with components in standard ranges:
+/// - h: 0.0..360.0 (degrees)
+/// - s: 0.0..1.0
+/// - l: 0.0..1.0
+#[derive(Debug, Clone, Copy)]
+pub struct Hsl {
+    pub h: f64,
+    pub s: f64,
+    pub l: f64,
+}
+
+/// Convert RGB (0-255 each) to HSL.
+pub fn rgb_to_hsl(r: u8, g: u8, b: u8) -> Hsl {
+    let r_norm = r as f64 / 255.0;
+    let g_norm = g as f64 / 255.0;
+    let b_norm = b as f64 / 255.0;
+
+    let max = r_norm.max(g_norm).max(b_norm);
+    let min = r_norm.min(g_norm).min(b_norm);
+    let delta = max - min;
+
+    let l = (max + min) / 2.0;
+
+    if delta < 1e-10 {
+        // Achromatic (grey)
+        return Hsl { h: 0.0, s: 0.0, l };
+    }
+
+    let s = if l <= 0.5 {
+        delta / (max + min)
+    } else {
+        delta / (2.0 - max - min)
+    };
+
+    let h = if (max - r_norm).abs() < 1e-10 {
+        let mut hue = 60.0 * ((g_norm - b_norm) / delta);
+        if hue < 0.0 {
+            hue += 360.0;
+        }
+        hue
+    } else if (max - g_norm).abs() < 1e-10 {
+        60.0 * ((b_norm - r_norm) / delta) + 120.0
+    } else {
+        60.0 * ((r_norm - g_norm) / delta) + 240.0
+    };
+
+    Hsl { h, s, l }
+}
+
+/// Convert HSL back to RGB (0-255 each).
+pub fn hsl_to_rgb(hsl: &Hsl) -> (u8, u8, u8) {
+    let Hsl { h, s, l } = *hsl;
+
+    if s < 1e-10 {
+        // Achromatic
+        let v = (l * 255.0).round() as u8;
+        return (v, v, v);
+    }
+
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
+    let p = 2.0 * l - q;
+    let h_norm = h / 360.0;
+
+    let r = hue_to_rgb(p, q, h_norm + 1.0 / 3.0);
+    let g = hue_to_rgb(p, q, h_norm);
+    let b = hue_to_rgb(p, q, h_norm - 1.0 / 3.0);
+
+    (
+        (r * 255.0).round() as u8,
+        (g * 255.0).round() as u8,
+        (b * 255.0).round() as u8,
+    )
+}
+
+/// Helper: convert a single hue channel to RGB component.
+fn hue_to_rgb(p: f64, q: f64, mut t: f64) -> f64 {
+    if t < 0.0 {
+        t += 1.0;
+    }
+    if t > 1.0 {
+        t -= 1.0;
+    }
+    if t < 1.0 / 6.0 {
+        return p + (q - p) * 6.0 * t;
+    }
+    if t < 1.0 / 2.0 {
+        return q;
+    }
+    if t < 2.0 / 3.0 {
+        return p + (q - p) * (2.0 / 3.0 - t) * 6.0;
+    }
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip: RGB -> HSL -> RGB should preserve values.
+    #[test]
+    fn round_trip_primary_colors() {
+        let test_cases: &[(u8, u8, u8)] = &[
+            (255, 0, 0),     // red
+            (0, 255, 0),     // green
+            (0, 0, 255),     // blue
+            (255, 255, 0),   // yellow
+            (0, 255, 255),   // cyan
+            (255, 0, 255),   // magenta
+            (255, 255, 255), // white
+            (0, 0, 0),       // black
+            (128, 128, 128), // grey
+        ];
+        for &(r, g, b) in test_cases {
+            let hsl = rgb_to_hsl(r, g, b);
+            let (r2, g2, b2) = hsl_to_rgb(&hsl);
+            assert!(
+                (r as i16 - r2 as i16).abs() <= 1
+                    && (g as i16 - g2 as i16).abs() <= 1
+                    && (b as i16 - b2 as i16).abs() <= 1,
+                "Round-trip failed for ({r}, {g}, {b}): got ({r2}, {g2}, {b2})"
+            );
+        }
+    }
+
+    /// Known HSL values for primary colors.
+    #[test]
+    fn known_hsl_values() {
+        // Pure red: H=0, S=1.0, L=0.5
+        let red = rgb_to_hsl(255, 0, 0);
+        assert!((red.h - 0.0).abs() < 1.0);
+        assert!((red.s - 1.0).abs() < 0.01);
+        assert!((red.l - 0.5).abs() < 0.01);
+
+        // Pure green: H=120, S=1.0, L=0.5
+        let green = rgb_to_hsl(0, 255, 0);
+        assert!((green.h - 120.0).abs() < 1.0);
+        assert!((green.s - 1.0).abs() < 0.01);
+
+        // Pure blue: H=240, S=1.0, L=0.5
+        let blue = rgb_to_hsl(0, 0, 255);
+        assert!((blue.h - 240.0).abs() < 1.0);
+        assert!((blue.s - 1.0).abs() < 0.01);
+    }
+
+    /// Achromatic colors should have S=0.
+    #[test]
+    fn achromatic_colors() {
+        for v in [0, 64, 128, 192, 255] {
+            let hsl = rgb_to_hsl(v, v, v);
+            assert!(
+                hsl.s < 0.01,
+                "Grey ({v},{v},{v}) should be achromatic, got S={:.3}",
+                hsl.s
+            );
+        }
+    }
+
+    /// White and black lightness values.
+    #[test]
+    fn white_and_black_lightness() {
+        let white = rgb_to_hsl(255, 255, 255);
+        assert!((white.l - 1.0).abs() < 0.01);
+
+        let black = rgb_to_hsl(0, 0, 0);
+        assert!(black.l < 0.01);
+    }
+
+    /// Round-trip with various mid-range colors.
+    #[test]
+    fn round_trip_mid_range_colors() {
+        let test_cases: &[(u8, u8, u8)] = &[
+            (100, 149, 237), // cornflowerblue
+            (255, 127, 80),  // coral
+            (220, 20, 60),   // crimson
+            (75, 0, 130),    // indigo
+            (250, 128, 114), // salmon
+        ];
+        for &(r, g, b) in test_cases {
+            let hsl = rgb_to_hsl(r, g, b);
+            let (r2, g2, b2) = hsl_to_rgb(&hsl);
+            assert!(
+                (r as i16 - r2 as i16).abs() <= 1
+                    && (g as i16 - g2 as i16).abs() <= 1
+                    && (b as i16 - b2 as i16).abs() <= 1,
+                "Round-trip failed for ({r}, {g}, {b}): got ({r2}, {g2}, {b2})"
+            );
+        }
+    }
+}

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -1,4 +1,6 @@
-//! Color utilities: palettes and gradient interpolation.
+//! Color utilities: palettes, gradient interpolation, HSL math, and CSS colors.
 
+pub mod css_colors;
 pub mod gradient;
+pub mod hsl;
 pub mod palette;

--- a/src/color/palette.rs
+++ b/src/color/palette.rs
@@ -1,26 +1,74 @@
 //! Named color palettes for different visual themes.
+//!
+//! Two-tier system:
+//! 1. Hand-tuned "featured" palettes (best quality, manually crafted gradients)
+//! 2. Auto-generated palettes for all 148 CSS Level 4 named colors
+//!
+//! Hand-tuned names always take priority over CSS auto-generation.
 
 use crossterm::style::Color;
 
-/// Returns the list of available palette names.
-pub fn palette_names() -> &'static [&'static str] {
-    &["classic", "gold", "cyan", "red", "monochrome", "purple"]
+use super::css_colors;
+use super::hsl;
+
+/// Hand-tuned palette names, in display order.
+/// These always win over CSS auto-generated palettes.
+const HAND_TUNED_NAMES: &[&str] = &[
+    "classic",
+    "gold",
+    "cyan",
+    "red",
+    "silver",
+    "purple",
+    "fire",
+    "ocean",
+    "synthwave",
+];
+
+/// Returns the list of hand-tuned (featured) palette names.
+pub fn hand_tuned_names() -> &'static [&'static str] {
+    HAND_TUNED_NAMES
+}
+
+/// Returns the full list of available palette names.
+/// Hand-tuned palettes first, then CSS colors (deduped).
+pub fn palette_names() -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = HAND_TUNED_NAMES.to_vec();
+    for css_name in css_colors::css_color_names() {
+        if !names.contains(&css_name) {
+            names.push(css_name);
+        }
+    }
+    names
 }
 
 /// Look up a palette by name. Returns classic if the name is unknown.
+///
+/// Priority: hand-tuned match -> "monochrome" alias -> CSS auto-gen -> fallback.
 pub fn palette_by_name(name: &str) -> Palette {
-    match name {
-        "classic" => Palette::classic(),
-        "gold" => Palette::gold(),
-        "cyan" => Palette::cyan(),
-        "red" => Palette::red(),
-        "monochrome" => Palette::monochrome(),
-        "purple" => Palette::purple(),
-        _ => {
-            eprintln!("Unknown palette '{}', using classic", name);
-            Palette::classic()
-        }
+    let lower = name.to_ascii_lowercase();
+
+    // Hand-tuned palettes
+    match lower.as_str() {
+        "classic" => return Palette::classic(),
+        "gold" => return Palette::gold(),
+        "cyan" => return Palette::cyan(),
+        "red" => return Palette::red(),
+        "silver" | "monochrome" => return Palette::silver(),
+        "purple" => return Palette::purple(),
+        "fire" => return Palette::fire(),
+        "ocean" => return Palette::ocean(),
+        "synthwave" => return Palette::synthwave(),
+        _ => {}
     }
+
+    // CSS auto-generated palette
+    if let Some(css) = css_colors::css_color_by_name(&lower) {
+        return generate_from_rgb(css.r, css.g, css.b);
+    }
+
+    eprintln!("Unknown palette '{}', using classic", name);
+    Palette::classic()
 }
 
 /// A color palette defines the colors used for a rain effect.
@@ -152,8 +200,8 @@ impl Palette {
         }
     }
 
-    /// Monochrome -- white/grey on black.
-    pub fn monochrome() -> Self {
+    /// Silver palette -- white/grey on black (formerly "monochrome").
+    pub fn silver() -> Self {
         Self {
             head: Color::Rgb {
                 r: 255,
@@ -211,6 +259,234 @@ impl Palette {
             background: Color::Reset,
         }
     }
+
+    /// Fire palette -- red/orange/yellow heat gradient.
+    pub fn fire() -> Self {
+        Self {
+            head: Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 200,
+            },
+            body_bright: Color::Rgb {
+                r: 255,
+                g: 120,
+                b: 0,
+            },
+            body_mid: Color::Rgb {
+                r: 200,
+                g: 40,
+                b: 0,
+            },
+            tail: Color::Rgb { r: 80, g: 10, b: 0 },
+            highlight: Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 100,
+            },
+            background: Color::Reset,
+        }
+    }
+
+    /// Ocean palette -- deep blue/teal aquatic feel.
+    pub fn ocean() -> Self {
+        Self {
+            head: Color::Rgb {
+                r: 200,
+                g: 240,
+                b: 255,
+            },
+            body_bright: Color::Rgb {
+                r: 0,
+                g: 120,
+                b: 220,
+            },
+            body_mid: Color::Rgb {
+                r: 0,
+                g: 60,
+                b: 140,
+            },
+            tail: Color::Rgb { r: 0, g: 20, b: 60 },
+            highlight: Color::Rgb {
+                r: 100,
+                g: 255,
+                b: 220,
+            },
+            background: Color::Reset,
+        }
+    }
+
+    /// Synthwave palette -- pink/purple/cyan retro neon.
+    pub fn synthwave() -> Self {
+        Self {
+            head: Color::Rgb {
+                r: 255,
+                g: 220,
+                b: 255,
+            },
+            body_bright: Color::Rgb {
+                r: 255,
+                g: 50,
+                b: 150,
+            },
+            body_mid: Color::Rgb {
+                r: 160,
+                g: 20,
+                b: 100,
+            },
+            tail: Color::Rgb { r: 60, g: 5, b: 40 },
+            highlight: Color::Rgb {
+                r: 0,
+                g: 255,
+                b: 255,
+            },
+            background: Color::Reset,
+        }
+    }
+}
+
+/// Auto-generate a palette from an RGB base color using HSL math.
+///
+/// For chromatic colors: derives head, body, tail, and highlight from the hue.
+/// For achromatic colors (greys): uses a neutral grey gradient.
+fn generate_from_rgb(r: u8, g: u8, b: u8) -> Palette {
+    let base = hsl::rgb_to_hsl(r, g, b);
+
+    // Achromatic detection (very low saturation)
+    if base.s < 0.05 {
+        return generate_achromatic(base.l);
+    }
+
+    let h = base.h;
+
+    // Head: near-white with hue tint
+    let head_hsl = hsl::Hsl {
+        h,
+        s: 0.15,
+        l: 0.92,
+    };
+    let (hr, hg, hb) = hsl::hsl_to_rgb(&head_hsl);
+
+    // Body bright: vivid signature color
+    let bright_l = base.l.clamp(0.40, 0.60);
+    let bright_s = base.s.max(0.6);
+    let bright_hsl = hsl::Hsl {
+        h,
+        s: bright_s,
+        l: bright_l,
+    };
+    let (br, bg, bb) = hsl::hsl_to_rgb(&bright_hsl);
+
+    // Body mid: darker version
+    let mid_hsl = hsl::Hsl {
+        h,
+        s: bright_s,
+        l: bright_l * 0.55,
+    };
+    let (mr, mg, mb) = hsl::hsl_to_rgb(&mid_hsl);
+
+    // Tail: very dark
+    let tail_hsl = hsl::Hsl {
+        h,
+        s: bright_s * 0.8,
+        l: bright_l * 0.2,
+    };
+    let (tr, tg, tb) = hsl::hsl_to_rgb(&tail_hsl);
+
+    // Highlight: complementary hue (180 degrees opposite)
+    let comp_h = (h + 180.0) % 360.0;
+    let highlight_hsl = hsl::Hsl {
+        h: comp_h,
+        s: 0.8,
+        l: 0.65,
+    };
+    let (hlr, hlg, hlb) = hsl::hsl_to_rgb(&highlight_hsl);
+
+    Palette {
+        head: Color::Rgb {
+            r: hr,
+            g: hg,
+            b: hb,
+        },
+        body_bright: Color::Rgb {
+            r: br,
+            g: bg,
+            b: bb,
+        },
+        body_mid: Color::Rgb {
+            r: mr,
+            g: mg,
+            b: mb,
+        },
+        tail: Color::Rgb {
+            r: tr,
+            g: tg,
+            b: tb,
+        },
+        highlight: Color::Rgb {
+            r: hlr,
+            g: hlg,
+            b: hlb,
+        },
+        background: Color::Reset,
+    }
+}
+
+/// Generate a grey-scale palette for achromatic CSS colors.
+fn generate_achromatic(base_l: f64) -> Palette {
+    // Clamp base lightness to a usable range for gradient visibility
+    let l = base_l.clamp(0.15, 0.85);
+
+    let head_hsl = hsl::Hsl {
+        h: 0.0,
+        s: 0.0,
+        l: (l + 0.35).min(0.95),
+    };
+    let bright_hsl = hsl::Hsl { h: 0.0, s: 0.0, l };
+    let mid_hsl = hsl::Hsl {
+        h: 0.0,
+        s: 0.0,
+        l: l * 0.55,
+    };
+    let tail_hsl = hsl::Hsl {
+        h: 0.0,
+        s: 0.0,
+        l: l * 0.2,
+    };
+
+    let (hr, hg, hb) = hsl::hsl_to_rgb(&head_hsl);
+    let (br, bg, bb) = hsl::hsl_to_rgb(&bright_hsl);
+    let (mr, mg, mb) = hsl::hsl_to_rgb(&mid_hsl);
+    let (tr, tg, tb) = hsl::hsl_to_rgb(&tail_hsl);
+
+    Palette {
+        head: Color::Rgb {
+            r: hr,
+            g: hg,
+            b: hb,
+        },
+        body_bright: Color::Rgb {
+            r: br,
+            g: bg,
+            b: bb,
+        },
+        body_mid: Color::Rgb {
+            r: mr,
+            g: mg,
+            b: mb,
+        },
+        tail: Color::Rgb {
+            r: tr,
+            g: tg,
+            b: tb,
+        },
+        highlight: Color::Rgb {
+            r: 255,
+            g: 255,
+            b: 255,
+        },
+        background: Color::Reset,
+    }
 }
 
 #[cfg(test)]
@@ -223,10 +499,17 @@ mod tests {
     }
 
     #[test]
+    fn hand_tuned_palettes_listed_first() {
+        let names = palette_names();
+        for (i, ht) in HAND_TUNED_NAMES.iter().enumerate() {
+            assert_eq!(names[i], *ht);
+        }
+    }
+
+    #[test]
     fn all_named_palettes_resolve() {
         for name in palette_names() {
             let p = palette_by_name(name);
-            // Verify head is an RGB color (not Reset/default)
             assert!(
                 matches!(p.head, Color::Rgb { .. }),
                 "palette '{}' head should be RGB",
@@ -239,11 +522,95 @@ mod tests {
     fn unknown_palette_falls_back_to_classic() {
         let unknown = palette_by_name("nonexistent");
         let classic = Palette::classic();
-        // Both should produce the same head color
         assert!(matches!(
             (unknown.head, classic.head),
             (Color::Rgb { r: r1, g: g1, b: b1 }, Color::Rgb { r: r2, g: g2, b: b2 })
             if r1 == r2 && g1 == g2 && b1 == b2
         ));
+    }
+
+    #[test]
+    fn monochrome_alias_returns_silver() {
+        let mono = palette_by_name("monochrome");
+        let silver = palette_by_name("silver");
+        assert!(matches!(
+            (mono.head, silver.head),
+            (Color::Rgb { r: r1, g: g1, b: b1 }, Color::Rgb { r: r2, g: g2, b: b2 })
+            if r1 == r2 && g1 == g2 && b1 == b2
+        ));
+    }
+
+    #[test]
+    fn hand_tuned_takes_priority_over_css() {
+        // "gold" exists both as hand-tuned and CSS. The hand-tuned should win.
+        let gold = palette_by_name("gold");
+        let hand_tuned = Palette::gold();
+        assert!(matches!(
+            (gold.body_bright, hand_tuned.body_bright),
+            (Color::Rgb { r: r1, g: g1, b: b1 }, Color::Rgb { r: r2, g: g2, b: b2 })
+            if r1 == r2 && g1 == g2 && b1 == b2
+        ));
+    }
+
+    #[test]
+    fn css_auto_generated_palette_works() {
+        // "coral" is not hand-tuned, should auto-generate
+        let coral = palette_by_name("coral");
+        assert!(matches!(coral.head, Color::Rgb { .. }));
+        assert!(matches!(coral.body_bright, Color::Rgb { .. }));
+        assert!(matches!(coral.highlight, Color::Rgb { .. }));
+    }
+
+    #[test]
+    fn achromatic_css_color_works() {
+        // "gray" is achromatic (128, 128, 128)
+        let gray = palette_by_name("gray");
+        assert!(matches!(gray.head, Color::Rgb { .. }));
+        assert!(matches!(gray.body_bright, Color::Rgb { .. }));
+    }
+
+    #[test]
+    fn very_dark_css_color_works() {
+        let dark = palette_by_name("darkred");
+        assert!(matches!(dark.head, Color::Rgb { .. }));
+    }
+
+    #[test]
+    fn very_light_css_color_works() {
+        let light = palette_by_name("snow");
+        assert!(matches!(light.head, Color::Rgb { .. }));
+    }
+
+    #[test]
+    fn no_duplicate_names() {
+        let names = palette_names();
+        let mut seen = std::collections::HashSet::new();
+        for name in &names {
+            assert!(seen.insert(name), "Duplicate palette name: {}", name);
+        }
+    }
+
+    #[test]
+    fn fire_ocean_synthwave_exist() {
+        for name in &["fire", "ocean", "synthwave"] {
+            let p = palette_by_name(name);
+            assert!(
+                matches!(p.head, Color::Rgb { .. }),
+                "palette '{}' should resolve",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn total_palette_count_is_reasonable() {
+        let names = palette_names();
+        // 9 hand-tuned + ~139 CSS (minus overlaps: cyan, red, gold, purple, silver = 5)
+        // = 9 + 143 = 152 (some CSS names like grey/gray duplicates)
+        assert!(
+            names.len() > 140,
+            "Expected 140+ palettes, got {}",
+            names.len()
+        );
     }
 }

--- a/src/effects/registry.rs
+++ b/src/effects/registry.rs
@@ -41,19 +41,51 @@ pub fn print_effects() {
 
 /// Print available color palettes to stdout (for --list-colors).
 pub fn print_palettes() {
-    println!("Available color palettes:");
-    for name in crate::color::palette::palette_names() {
+    use crate::color::palette;
+
+    // Featured (hand-tuned) palettes with descriptions
+    println!("Featured palettes:");
+    for name in palette::hand_tuned_names() {
         let desc = match *name {
             "classic" => "Green phosphor (the Matrix default)",
             "gold" => "Warm amber/gold CRT feel",
             "cyan" => "Cold ice-blue digital",
             "red" => "Crimson danger/alert",
-            "monochrome" => "White/grey on black",
+            "silver" => "White/grey on black",
             "purple" => "Violet synthwave",
+            "fire" => "Red/orange/yellow heat gradient",
+            "ocean" => "Deep blue/teal aquatic",
+            "synthwave" => "Pink/purple/cyan retro neon",
             _ => "",
         };
         println!("  {:<12} - {}", name, desc);
     }
+
+    // CSS named colors in compact columns
+    let css_names: Vec<&str> = palette::palette_names()
+        .into_iter()
+        .filter(|n| !palette::hand_tuned_names().contains(n))
+        .collect();
+
+    println!();
+    println!(
+        "CSS named colors ({} additional -- use any as --color <name>):",
+        css_names.len()
+    );
+
+    // Print in columns (4 per row, 20 chars wide)
+    const COLS: usize = 4;
+    const COL_WIDTH: usize = 22;
+    for chunk in css_names.chunks(COLS) {
+        print!("  ");
+        for name in chunk {
+            print!("{:<width$}", name, width = COL_WIDTH);
+        }
+        println!();
+    }
+
+    println!();
+    println!("Aliases: monochrome -> silver");
 }
 
 /// Print available character sets to stdout (for --list-charsets).


### PR DESCRIPTION
## Summary
- Two-tier palette system: 9 hand-tuned featured palettes + all 148 CSS Level 4 named colors with auto-generated gradients via HSL math
- 3 new multi-hue palettes: fire, ocean, synthwave
- Renamed "monochrome" to "silver" (CSS standard); backward-compatible alias kept
- Grouped `--list-colors` output: featured palettes with descriptions, CSS names in columns
- 19 new unit tests (47 total)

## Test plan
- [x] `cargo fmt && cargo clippy && cargo test` -- all pass (47/47)
- [ ] `cargo run -- --list-colors` -- grouped output
- [ ] `cargo run -- --color coral` -- CSS auto-generated palette
- [ ] `cargo run -- --color fire` / `ocean` / `synthwave` -- new hand-tuned palettes
- [ ] `cargo run -- --color monochrome` -- backward compat alias
- [ ] `cargo run -- --random` -- randomization picks from full list

🤖 Generated with [Claude Code](https://claude.com/claude-code)