### PR TITLE
chore: add .gitignore and GitHub Sponsors config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+# Voluntary financial support for DigitalRain development.
+# These links appear on the GitHub "Sponsor" button.
+
+github: HerbHall
+ko_fi: herbhall
+buy_me_a_coffee: herbhall

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # IDE
 .idea/
 .vscode/
+.claude/
 *.swp
 *.swo
 


### PR DESCRIPTION
## Summary

- Add `.claude/` to `.gitignore` to exclude local Claude Code settings from the repo
- Add `.github/FUNDING.yml` for GitHub Sponsors button (GitHub, Ko-fi, Buy Me a Coffee)

## Test plan

- [x] Verify `.claude/` no longer shows as untracked
- [x] Verify FUNDING.yml renders correctly on GitHub repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)